### PR TITLE
Refactor credential and configuration usage.

### DIFF
--- a/python/lsst/ctrl/iip/ATArchiver.py
+++ b/python/lsst/ctrl/iip/ATArchiver.py
@@ -37,10 +37,7 @@ from time import sleep
 import threading
 from threading import Lock
 from lsst.ctrl.iip.const import *
-from lsst.ctrl.iip.Scoreboard import Scoreboard
 from lsst.ctrl.iip.Credentials import Credentials
-from lsst.ctrl.iip.JobScoreboard import JobScoreboard
-from lsst.ctrl.iip.AckScoreboard import AckScoreboard
 from lsst.ctrl.iip.Consumer import Consumer
 from lsst.ctrl.iip.AsyncPublisher import AsyncPublisher
 from lsst.ctrl.iip.iip_base import iip_base

--- a/python/lsst/ctrl/iip/AckScoreboard.py
+++ b/python/lsst/ctrl/iip/AckScoreboard.py
@@ -54,7 +54,7 @@ class AckScoreboard(Scoreboard):
     DB_INSTANCE = None
   
 
-    def __init__(self, db_type, db_instance):
+    def __init__(self, db_type, db_instance, cred, cdm):
         """After connecting to the Redis database instance 
            ACK_SCOREBOARD_DB, this redis database is flushed 
            for a clean start. 
@@ -66,15 +66,10 @@ class AckScoreboard(Scoreboard):
            3) As new acks with a particular TIMED_ACK_ID are received, the data is added to that row.
            4) After a timer event elapses, the scoreboard is locked and checked  to see which ACKs were received.
         """
+        super().__init__(cred, cdm)
         LOGGER.info('Setting up AckScoreboard')
         self.DB_TYPE = db_type
         self.DB_INSTANCE = db_instance
-        try:
-            Scoreboard.__init__(self)
-        except L1RabbitConnectionError as e:
-            LOGGER.error('Failed to make connection to Message Broker:  ', e.arg)
-            print("No Auditing for YOU")
-            raise L1Error('Calling super.init in AckScoreboard init caused: ', e.arg)
 
         self._redis = self.connect()
         self._redis.flushdb()

--- a/python/lsst/ctrl/iip/ArchiveController.py
+++ b/python/lsst/ctrl/iip/ArchiveController.py
@@ -107,7 +107,7 @@ class ArchiveController(iip_base):
         # Set up Incr Scbd...
         try:
             LOGGER.info('Setting up Archive Incr Scoreboard')
-            self.INCR_SCBD = IncrScoreboard('ARC_CTRL_RCPT_SCBD', self.incr_db_instance)
+            self.INCR_SCBD = IncrScoreboard('ARC_CTRL_RCPT_SCBD', self.incr_db_instance, cred, cdm)
         except L1RedisError as e:
             LOGGER.error("DMCS unable to complete setup_scoreboards - " + \
                          "No Redis connect: %s" % e.args)

--- a/python/lsst/ctrl/iip/BacklogScoreboard.py
+++ b/python/lsst/ctrl/iip/BacklogScoreboard.py
@@ -58,16 +58,11 @@ class BacklogScoreboard(Scoreboard):
     DB_TYPE = ""
   
 
-    def __init__(self, db_type, db_instance):
+    def __init__(self, db_type, db_instance, cred, cdm):
+        super().__init__(cred, cdm)
         self.DB_TYPE = db_type
         self.DB_INSTANCE = db_instance
         self._session_id = str(1)
-        try:
-            Scoreboard.__init__(self)
-        except L1RabbitConnectionError as e:
-            LOGGER.error('Failed to make connection to Message Broker:  ', e.arg)
-            print("No Monitoring for YOU")
-            raise L1Error('Calling super.init in StateScoreboard init caused: ', e.arg)
 
         try:
             self._redis = self.connect()
@@ -145,25 +140,3 @@ class BacklogScoreboard(Scoreboard):
         monitor_data['TIME'] = get_epoch_timestamp()
         monitor_data['DATA_TYPE'] = self.DB_TYPE
         return monitor_data
-
-
-
-
-def main():
-  bls = BacklogScoreboard()
-  print("Backlog Scoreboard seems to be running OK")
-  time.sleep(2)
-  print("Done.")
-  #jbs.charge_database()
-  #jbs.print_all()
-  #Ps = jbs.get_value_for_job(str(1), 'PAIRS')
-  #print "printing Ps"
-  #print Ps
-  #ppps = eval(Ps)
-  #pps = ppps.keys()
-  #print "final line"
-  #print ppps == pairs
-
-
-
-if __name__ == "__main__": main()

--- a/python/lsst/ctrl/iip/DMCS.py
+++ b/python/lsst/ctrl/iip/DMCS.py
@@ -38,8 +38,6 @@ from threading import ThreadError
 from lsst.ctrl.iip.Credentials import Credentials
 from lsst.ctrl.iip.ThreadManager import ThreadManager
 from lsst.ctrl.iip.const import *
-from lsst.ctrl.iip.Scoreboard import Scoreboard
-from lsst.ctrl.iip.JobScoreboard import JobScoreboard
 from lsst.ctrl.iip.AckScoreboard import AckScoreboard
 from lsst.ctrl.iip.StateScoreboard import StateScoreboard
 from lsst.ctrl.iip.BacklogScoreboard import BacklogScoreboard
@@ -1447,12 +1445,14 @@ class DMCS(iip_base):
          
 
     def setup_scoreboards(self):
+        cred = self.getCredentials()
+        config = self.getConfiguration()
         try: 
             LOGGER.info('Setting up DMCS Scoreboards')
-            self.BACKLOG_SCBD = BacklogScoreboard('DMCS_BACKLOG_SCBD', self.backlog_db_instance)
-            self.ACK_SCBD = AckScoreboard('DMCS_ACK_SCBD', self.ack_db_instance)
-            self.INCR_SCBD = IncrScoreboard('DMCS_INCR_SCBD', self.incr_db_instance)
-            self.STATE_SCBD = StateScoreboard('DMCS_STATE_SCBD', self.state_db_instance, self.ddict, self.rdict)
+            self.BACKLOG_SCBD = BacklogScoreboard('DMCS_BACKLOG_SCBD', self.backlog_db_instance, cred, config)
+            self.ACK_SCBD = AckScoreboard('DMCS_ACK_SCBD', self.ack_db_instance, cred, config)
+            self.INCR_SCBD = IncrScoreboard('DMCS_INCR_SCBD', self.incr_db_instance, cred, config)
+            self.STATE_SCBD = StateScoreboard('DMCS_STATE_SCBD', self.state_db_instance, self.ddict, self.rdict, cred, config)
         except L1RabbitConnectionError as e: 
             LOGGER.error("DMCS unable to complete setup_scoreboards - No Rabbit Connect: %s" % e.args)
         except L1RedisError as e: 

--- a/python/lsst/ctrl/iip/DistributorScoreboard.py
+++ b/python/lsst/ctrl/iip/DistributorScoreboard.py
@@ -42,17 +42,11 @@ class DistributorScoreboard(Scoreboard):
     DB_TYPE = ""
     DB_INSTANCE = None
 
-    def __init__(self, db_type, db_instance, ddict):
+    def __init__(self, db_type, db_instance, ddict, cred, cdm):
+        super().__init__(cred, cdm)
         LOGGER.info('Setting up DistributorScoreboard')
         self.DB_TYPE = db_type
         self.DB_INSTANCE = db_instance
-
-        try:
-            Scoreboard.__init__(self)
-        except L1RabbitConnectionError as e:
-            LOGGER.error('Failed to make connection to Message Broker: %s', e.arg)
-            print("No Monitoring for YOU")
-            raise L1Error('Calling super.init in DistScoreboard init caused: %s', e.arg)
 
         try:
             self._redis = self.connect()

--- a/python/lsst/ctrl/iip/IncrScoreboard.py
+++ b/python/lsst/ctrl/iip/IncrScoreboard.py
@@ -41,7 +41,8 @@ class IncrScoreboard(Scoreboard):
     RECEIPT_SEQUENCE_NUM = 'RECEIPT_SEQUENCE_NUM' 
   
 
-    def __init__(self, db_type, db_instance):
+    def __init__(self, db_type, db_instance, cred, cdm):
+        super().__init__(cred, cdm)
         LOGGER.info('Setting up IncrScoreboard')
         self.DB_TYPE = db_type
         self.DB_INSTANCE = db_instance

--- a/python/lsst/ctrl/iip/JobScoreboard.py
+++ b/python/lsst/ctrl/iip/JobScoreboard.py
@@ -68,7 +68,7 @@ class JobScoreboard(Scoreboard):
     prp = toolsmod.prp
   
 
-    def __init__(self, db_type, db_instance):
+    def __init__(self, db_type, db_instance, cred, cdm):
         """After connecting to the Redis database instance 
            JOB_SCOREBOARD_DB, this redis database is flushed 
            for a clean start. A 'charge_database' method is 
@@ -93,15 +93,11 @@ class JobScoreboard(Scoreboard):
            COMPLETE
            TERMINATED
         """
+        super().__init__(cred, cdm)
         LOGGER.info('Setting up JobScoreboard')
         self.DB_TYPE = db_type
         self.DB_INSTANCE = db_instance
         self._session_id = str(1)
-        try:
-            Scoreboard.__init__(self)
-        except Exception as e:
-            LOGGER.error('Job SCBD Auditor Failed to make connection to Message Broker:  ', e.arg)
-            raise L1RabbitConnectionError('Calling super.init() in JobScoreboard init caused: ', e.arg)
 
         try:
             self._redis = self.connect()

--- a/python/lsst/ctrl/iip/Scoreboard.py
+++ b/python/lsst/ctrl/iip/Scoreboard.py
@@ -33,7 +33,7 @@ from lsst.ctrl.iip.iip_base import iip_base
 
 LOGGER = logging.getLogger(__name__)
 
-class Scoreboard(iip_base):
+class Scoreboard:
     """This is the parent class of the three scoreboard classes. 
        It, and they, form an interface for the Redis in-memory DB
        that continually stores state information about components and jobs.
@@ -41,18 +41,15 @@ class Scoreboard(iip_base):
 
     AUDIT_QUEUE = 'audit_consume'
 
-    def __init__(self, filename=None):
+    def __init__(self, cred, cdm):
 
-        cred = Credentials('iip_cred.yaml')
-        name = cred.getUser('service_user')
-        passwd = cred.getPasswd('service_passwd')
-
-        if filename is not None:
-            raise Exception("DEBUG: Expected that no filename was present:  Got %s " % filename)
-        self.cdm = self.loadConfigFile('L1SystemCfg.yaml')
+        self.cred = cred
+        self.cdm = cdm
 
         broker_address = self.cdm['ROOT']['BASE_BROKER_ADDR']
-        self.broker_url = "amqp://" + name + ":" + passwd + "@" + str(broker_address)
+        name = cred.getUser('service_user')
+        passwd = cred.getUser('service_passwd')
+        self.broker_url = "amqp://%s:%s@%s" % (name, passwd, broker_address)
 
         self.audit_format = "YAML"
         if 'AUDIT_MSG_FORMAT' in self.cdm['ROOT']:

--- a/python/lsst/ctrl/iip/StateScoreboard.py
+++ b/python/lsst/ctrl/iip/StateScoreboard.py
@@ -70,16 +70,12 @@ class StateScoreboard(Scoreboard):
     prp = toolsmod.prp
   
 
-    def __init__(self, db_type, db_instance, ddict, rdict):
+    def __init__(self, db_type, db_instance, ddict, rdict, cred, cdm):
+        super().__init__(cred, cdm)
+
         self.DB_TYPE = db_type
         self.DB_INSTANCE = db_instance
         self._session_id = str(1)
-        try:
-            Scoreboard.__init__(self)
-        except L1RabbitConnectionError as e:
-            LOGGER.error('Failed to make connection to Message Broker:  ', e.arg)
-            print("No Monitoring for YOU")
-            raise L1Error('Calling super.init in StateScoreboard init caused: ', e.arg)
 
         try:
             self._redis = self.connect()


### PR DESCRIPTION
The Scoreboard base class would load the configuration information from disk
a second time after the service started (and had previously loaded the configuration).
This update fixes that, and uses the credential information to establish the amqp link
in the base class.