### PR TITLE
Pending message can cause a crash in the OCS Bridge

### DIFF
--- a/python/lsst/ctrl/iip/AsyncPublisher.py
+++ b/python/lsst/ctrl/iip/AsyncPublisher.py
@@ -44,10 +44,6 @@ class AsyncPublisher(threading.Thread):
 
         self._message_handler = YamlHandler()
 
-        try:
-            self.connect()
-        except Exception:
-            LOGGER.error('No channel - connection channel is None')
 
     def connect(self):
         self._connection = pika.SelectConnection(pika.URLParameters(self._url),
@@ -119,4 +115,8 @@ class AsyncPublisher(threading.Thread):
         LOGGER.info('Stopped')
 
     def run(self):
+        try:
+            self.connect()
+        except Exception:
+            LOGGER.error('No channel - connection channel is None')
         self._connection.ioloop.start()

--- a/python/lsst/ctrl/iip/ocs/Bridge.py
+++ b/python/lsst/ctrl/iip/ocs/Bridge.py
@@ -58,10 +58,8 @@ class Bridge(iip_base):
 
         url = 'amqp://%s:%s@%s' % (self.service_user, self.service_passwd, broker)
         self.bookkeeping_publisher = AsyncPublisher(url, 'bookkeeping')
-        self.bookkeeping_publisher.start()
 
         self.ack_publisher = AsyncPublisher(url, 'ack_publisher')
-        self.ack_publisher.start()
 
         self.devices = None
 
@@ -72,7 +70,6 @@ class Bridge(iip_base):
         # setup rabbitmq consumer to listen to DMCS
         self.consumer = Consumer(url, self.consumeq, "Thread-dmcs_ocs_publish",
                                  self.responder.on_dmcs_message, "YAML")
-        self.consumer.start()
 
         self.telemetry_forwarder = TelemetryForwarder(self, url)
 
@@ -108,6 +105,13 @@ class Bridge(iip_base):
         attempting to retrieve messages each device is capable of retrieving.
         This method returns when self.shut_down_event is set.
         """
+
+        # start RabbitMQ async listeners
+        self.bookkeeping_publisher.start()
+        self.ack_publisher.start()
+        self.consumer.start()
+        self.telemetry_forwarder.start()
+
         LOGGER.info("listening")
         print("listening")
         while True:

--- a/python/lsst/ctrl/iip/ocs/TelemetryForwarder.py
+++ b/python/lsst/ctrl/iip/ocs/TelemetryForwarder.py
@@ -34,7 +34,6 @@ class TelemetryForwarder:
         # setup rabbitmq consumer to listen to for telementry
         self.consumer = Consumer(url, "telemetry_queue", "Thread-dmcs_ocs_publish",
                                  self.on_telemetry_message, "YAML")
-        self.consumer.start()
 
     def on_telemetry_message(self, ch, method, properties, msg_dict):
         """ Calls the appropriate OCS action handler according to message type, for a device
@@ -56,6 +55,9 @@ class TelemetryForwarder:
             return
 
         device.outgoing_message_handler(msg_dict)
+
+    def start(self):
+        self.consumer.start()
 
     def stop(self):
         self.consumer.stop()

--- a/python/lsst/ctrl/iip/ocs/messages/DefaultMessages.py
+++ b/python/lsst/ctrl/iip/ocs/messages/DefaultMessages.py
@@ -31,6 +31,19 @@ class DefaultMessages(Messages):
         self.log_events = ["summaryState", "settingVersions", "errorCode", "appliedSettingsMatchStart",
                            "settingsApplied"]
 
+        self.translation_table = { 'enable': 'ENABLE',
+                                   'start': 'START',
+                                   'disable': 'DISABLE',
+                                   'enterControl': 'ENTER_CONTROL',
+                                   'exitControl': 'EXIT_CONTROL',
+                                   'standby': 'STANDBY',
+                                   'abort': 'ABORT' }
+
+
+
+    def translate(self, command):
+        return self.translation_table[command]
+
     def build_settingVersions_object(self, data, msg):
         """Build settingVersions SAL message object
         @param data: settingVersions SAL structure


### PR DESCRIPTION
These changes were made to delay the start of RabbitMQ message taking until after all of the SAL objects were properly registered with the system.  Also fixed an issue where there were events not being passed properly because of name translations that needed to be done.